### PR TITLE
Improve info string for SpawnEntityAction duration

### DIFF
--- a/src/main/java/de/iani/cubequest/actions/SpawnEntityAction.java
+++ b/src/main/java/de/iani/cubequest/actions/SpawnEntityAction.java
@@ -82,7 +82,7 @@ public class SpawnEntityAction extends LocatedAction {
         TextComponent typeComp = new TextComponent("Entity: " + this.entityType + " ");
         typeComp.setColor(ChatColor.DARK_AQUA);
 
-        TextComponent durationComp = new TextComponent("for " + this.duration + " Ticks ");
+        TextComponent durationComp = new TextComponent(duration > 0 ? "für " + this.duration + " Ticks " : "permanent ");
         typeComp.addExtra(durationComp);
 
         String nbtString = this.nbtTag == null ? null


### PR DESCRIPTION
Wenn `duration <= 0`, wird bei `/quest info` jetzt "permanent" angezeigt, ansonsten nicht "for x Ticks", sondern "für x Ticks"